### PR TITLE
Add Discord.Js and role endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -903,6 +903,33 @@
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
     },
+    "discord.js": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-11.5.1.tgz",
+      "integrity": "sha512-tGhV5xaZXE3Z+4uXJb3hYM6gQ1NmnSxp9PClcsSAYFVRzH6AJH74040mO3afPDMWEAlj8XsoPXXTJHTxesqcGw==",
+      "requires": {
+        "long": "^4.0.0",
+        "prism-media": "^0.0.3",
+        "snekfetch": "^3.6.4",
+        "tweetnacl": "^1.0.0",
+        "ws": "^6.0.0"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
+          "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
+        },
+        "ws": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
+      }
+    },
     "dottie": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.1.tgz",
@@ -2491,6 +2518,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "make-iterator": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
@@ -3031,6 +3063,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
+    },
+    "prism-media": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-0.0.3.tgz",
+      "integrity": "sha512-c9KkNifSMU/iXT8FFTaBwBMr+rdVcN+H/uNv1o+CuFeTThNZNTOrQ+RgXA1yL/DeLk098duAeRPP3QNPNbhxYQ=="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -3588,6 +3625,11 @@
           }
         }
       }
+    },
+    "snekfetch": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/snekfetch/-/snekfetch-3.6.4.tgz",
+      "integrity": "sha512-NjxjITIj04Ffqid5lqr7XdgwM7X61c/Dns073Ly170bPQHLm6jkmelye/eglS++1nfTWktpP6Y2bFXjdPlQqdw=="
     },
     "source-map": {
       "version": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/validator": "^10.11.3",
     "@types/websocket": "0.0.40",
     "body-parser": "^1.19.0",
+    "discord.js": "^11.5.1",
     "ejs": "^2.7.1",
     "express": "^4.17.1",
     "express-ws": "^4.0.0",

--- a/src/api/bot/project/roles/post.ts
+++ b/src/api/bot/project/roles/post.ts
@@ -27,10 +27,16 @@ module.exports = async (req: Request, res: Response) => {
         genericServerError("Unable to get guild details", res);
         return;
     }
-    // Must have a role in the body (JSON)
-    if (!req.body.name) {
+
+    // Must have a proper roles in the body (JSON)
+    if (!req.body.appName) {
         res.status(422);
-        res.end(`Missing role name`);
+        res.end(`Missing appName`);
+        return;
+    }
+    if (!req.body.subRole) {
+        res.status(422);
+        res.end(`Missing subRole`);
         return;
     }
 
@@ -38,35 +44,39 @@ module.exports = async (req: Request, res: Response) => {
 
     // If trying to create a role for a project, make sure the project exists
     let Projects = await getProjectsByUserDiscordId(user.id);
-    if (Projects.filter(project => req.body.name.includes(project.appName)).length == 0) {
+    if (Projects.filter(project => req.body.appName == project.appName).length == 0) {
         res.status(422);
-        res.end(`The project doesn't exist, or the role does not contain the project name`);
+        res.end(`The project doesn't exist`);
         return;
     }
 
-    if (!checkAllowedProjectSubRoles(req.body.name)) {
+    if (allowedProjectSubRoles.filter(subRole => req.body.subRole == subRole).length == 0) {
         res.status(422);
-        res.end(`Invalid project sub-role. Allowed values are: "${allowedProjectSubRoles.join(`" , "`)}"`);
+        res.end(`Invalid project subRole. Allowed values are: "${allowedProjectSubRoles.join(`" , "`)}"`);
         return;
     }
 
     const server = GetGuild();
     if (!server) return;
 
+    const roleName = req.body.appName + " " + capitalizeFirstLetter(req.body.subRole);
+    // Check that the role doesn't already exist
+    if (server.roles.array().filter(role => role.name == roleName).length > 0) {
+        res.status(401);
+        res.end("Role already exists");
+        return;
+    }
+
     server.createRole({
-        name: req.body.name,
+        name: req.body.appName + " " + capitalizeFirstLetter(req.body.subRole),
         mentionable: true,
         color: req.body.color
     });
 
-    res.json(roles);
+    res.end("Success");
 };
 
 const allowedProjectSubRoles = ["translator", "dev", "beta tester"];
-
-function checkAllowedProjectSubRoles(roleName: string) {
-    for (let SubRole in allowedProjectSubRoles) {
-        if (roleName.toLowerCase().includes(SubRole)) return true;
-    }
-    return false;
+function capitalizeFirstLetter(s: string) {
+    return s.charAt(0).toUpperCase() + s.slice(1);
 }

--- a/src/api/bot/project/roles/post.ts
+++ b/src/api/bot/project/roles/post.ts
@@ -1,0 +1,72 @@
+import { Request, Response } from "express-serve-static-core";
+import { GetGuildUser, GetGuild } from "../../../../common/discord";
+import { Role } from "discord.js";
+import { genericServerError, GetDiscordUser, getProjectsByUserDiscordId } from "../../../../common/helpers";
+
+module.exports = async (req: Request, res: Response) => {
+    if (!req.headers.authorization) {
+        res.status(422);
+        res.json(JSON.stringify({
+            error: "Malformed request",
+            reason: "Missing authorization header"
+        }));
+        return;
+    }
+
+    let accessToken = req.headers.authorization.replace("Bearer", "");
+
+    const user = await GetDiscordUser(accessToken).catch((err) => genericServerError(err, res));
+    if (!user) {
+        res.status(401);
+        res.end(`Invalid accessToken`);
+        return;
+    }
+
+    const guildMember = await GetGuildUser(user.id);
+    if (!guildMember) {
+        genericServerError("Unable to get guild details", res);
+        return;
+    }
+    // Must have a role in the body (JSON)
+    if (!req.body.name) {
+        res.status(422);
+        res.end(`Missing role name`);
+        return;
+    }
+
+    let roles: Role[] = guildMember.roles.array().map(role => { delete role.guild; return role });
+
+    // If trying to create a role for a project, make sure the project exists
+    let Projects = await getProjectsByUserDiscordId(user.id);
+    if (Projects.filter(project => req.body.name.includes(project.appName)).length == 0) {
+        res.status(422);
+        res.end(`The project doesn't exist, or the role does not contain the project name`);
+        return;
+    }
+
+    if (!checkAllowedProjectSubRoles(req.body.name)) {
+        res.status(422);
+        res.end(`Invalid project sub-role. Allowed values are: "${allowedProjectSubRoles.join(`" , "`)}"`);
+        return;
+    }
+
+    const server = GetGuild();
+    if (!server) return;
+
+    server.createRole({
+        name: req.body.name,
+        mentionable: true,
+        color: req.body.color
+    });
+
+    res.json(roles);
+};
+
+const allowedProjectSubRoles = ["translator", "dev", "beta tester"];
+
+function checkAllowedProjectSubRoles(roleName: string) {
+    for (let SubRole in allowedProjectSubRoles) {
+        if (roleName.toLowerCase().includes(SubRole)) return true;
+    }
+    return false;
+}

--- a/src/api/bot/project/roles/post.ts
+++ b/src/api/bot/project/roles/post.ts
@@ -13,7 +13,7 @@ module.exports = async (req: Request, res: Response) => {
         return;
     }
 
-    let accessToken = req.headers.authorization.replace("Bearer", "");
+    let accessToken = req.headers.authorization.replace("Bearer ", "");
 
     const user = await GetDiscordUser(accessToken).catch((err) => genericServerError(err, res));
     if (!user) {

--- a/src/api/bot/project/roles/post.ts
+++ b/src/api/bot/project/roles/post.ts
@@ -40,8 +40,6 @@ module.exports = async (req: Request, res: Response) => {
         return;
     }
 
-    let roles: Role[] = guildMember.roles.array().map(role => { delete role.guild; return role });
-
     // If trying to create a role for a project, make sure the project exists
     let Projects = await getProjectsByUserDiscordId(user.id);
     if (Projects.filter(project => req.body.appName == project.appName).length == 0) {
@@ -68,7 +66,7 @@ module.exports = async (req: Request, res: Response) => {
     }
 
     server.createRole({
-        name: req.body.appName + " " + capitalizeFirstLetter(req.body.subRole),
+        name: roleName,
         mentionable: true,
         color: req.body.color
     });

--- a/src/api/bot/user/roles/delete.ts
+++ b/src/api/bot/user/roles/delete.ts
@@ -29,20 +29,23 @@ module.exports = async (req: Request, res: Response) => {
     }
 
     // Must have a role in the body (JSON)
-    if (req.body.role) {
-        // Check that the user has the role
-        let roles: Role[] = guildMember.roles.array().filter(role => role.name == req.body.role);
-        if (roles.length == 0) InvalidRole(res);
+    if (!req.body.name) {
+        res.status(401);
+        res.end(`Missing role name`);
+        return;
+    }
 
+    // Check that the user has the role
+    let roles: Role[] = guildMember.roles.array().filter(role => role.name == req.body.role);
+    if (roles.length == 0) InvalidRole(res);
 
-        switch (req.body.role) {
-            case "Developer":
-                guildMember.removeRole(roles[0]);
-                res.send("Success");
-                break;
-            default:
-                InvalidRole(res);
-        }
+    switch (req.body.name) {
+        case "Developer":
+            guildMember.removeRole(roles[0]);
+            res.send("Success");
+            break;
+        default:
+            InvalidRole(res);
     }
 };
 

--- a/src/api/bot/user/roles/delete.ts
+++ b/src/api/bot/user/roles/delete.ts
@@ -1,0 +1,55 @@
+import { Request, Response } from "express-serve-static-core";
+import { GetGuildUser } from "../../../../common/discord";
+import { Role } from "discord.js";
+import { genericServerError, GetDiscordUser, getProjectsByUserDiscordId } from "../../../../common/helpers";
+
+module.exports = async (req: Request, res: Response) => {
+    if (!req.headers.authorization) {
+        res.status(422);
+        res.json(JSON.stringify({
+            error: "Malformed request",
+            reason: "Missing authorization header"
+        }));
+        return;
+    }
+
+    let accessToken = req.headers.authorization.replace("Bearer ", "");
+
+    const user = await GetDiscordUser(accessToken).catch((err) => genericServerError(err, res));
+    if (!user) {
+        res.status(401);
+        res.end(`Invalid access token`);
+        return;
+    }
+
+    const guildMember = await GetGuildUser(user.id);
+    if (!guildMember) {
+        genericServerError("Unable to get guild details", res);
+        return;
+    }
+
+    // Must have a role in the body (JSON)
+    if (req.body.role) {
+        // Check that the user has the role
+        let roles: Role[] = guildMember.roles.array().filter(role => role.name == req.body.role);
+        if (roles.length == 0) InvalidRole(res);
+
+
+        switch (req.body.role) {
+            case "Developer":
+                guildMember.removeRole(roles[0]);
+                res.send("Success");
+                break;
+            default:
+                InvalidRole(res);
+        }
+    }
+};
+
+function InvalidRole(res: Response) {
+    res.status(422);
+    res.json({
+        error: "Malformed request",
+        reason: "Invalid role"
+    });
+}

--- a/src/api/bot/user/roles/get.ts
+++ b/src/api/bot/user/roles/get.ts
@@ -1,21 +1,28 @@
 import { Request, Response } from "express-serve-static-core";
 import { GetGuildUser } from "../../../../common/discord";
 import { Role } from "discord.js";
-import { genericServerError } from "../../../../common/helpers";
+import { genericServerError, GetDiscordUser } from "../../../../common/helpers";
 
 module.exports = async (req: Request, res: Response) => {
-    let discordId = req.query.discordId;
-
-    if (!discordId) {
+    if (!req.headers.authorization) {
         res.status(422);
         res.json(JSON.stringify({
             error: "Malformed request",
-            reason: "Missing discordId query"
+            reason: "Missing authorization header"
         }));
         return;
     }
 
-    const guildMember = await GetGuildUser(discordId);
+    let accessToken = req.headers.authorization.replace("Bearer ", "");
+
+    const user = await GetDiscordUser(accessToken).catch((err) => genericServerError(err, res));
+    if (!user) {
+        res.status(401);
+        res.end(`Invalid access token`);
+        return;
+    }
+
+    const guildMember = await GetGuildUser(user.id);
     if (!guildMember) {
         genericServerError("Unable to get guild details", res);
         return;

--- a/src/api/bot/user/roles/get.ts
+++ b/src/api/bot/user/roles/get.ts
@@ -14,7 +14,7 @@ module.exports = async (req: Request, res: Response) => {
         }));
         return;
     }
-    
+
     const guildMember = await GetGuildUser(discordId);
     if (!guildMember) {
         genericServerError("Unable to get guild details", res);

--- a/src/api/bot/user/roles/get.ts
+++ b/src/api/bot/user/roles/get.ts
@@ -1,0 +1,27 @@
+import { Request, Response } from "express-serve-static-core";
+import { GetGuildUser } from "../../../../common/discord";
+import { Role } from "discord.js";
+import { genericServerError } from "../../../../common/helpers";
+
+module.exports = async (req: Request, res: Response) => {
+    let discordId = req.query.discordId;
+
+    if (!discordId) {
+        res.status(422);
+        res.json(JSON.stringify({
+            error: "Malformed request",
+            reason: "Missing discordId query"
+        }));
+        return;
+    }
+    
+    const guildMember = await GetGuildUser(discordId);
+    if (!guildMember) {
+        genericServerError("Unable to get guild details", res);
+        return;
+    }
+
+    let roles: Role[] = guildMember.roles.array().map(role => { delete role.guild; return role });
+
+    res.json(roles);
+};

--- a/src/api/bot/user/roles/put.ts
+++ b/src/api/bot/user/roles/put.ts
@@ -1,0 +1,59 @@
+import { Request, Response } from "express-serve-static-core";
+import { GetGuildUser, GetGuildRoles } from "../../../../common/discord";
+import { Role } from "discord.js";
+import { genericServerError, GetDiscordUser } from "../../../../common/helpers";
+
+module.exports = async (req: Request, res: Response) => {
+    if (!req.headers.authorization) {
+        res.status(422);
+        res.json(JSON.stringify({
+            error: "Malformed request",
+            reason: "Missing authorization header"
+        }));
+        return;
+    }
+
+    let accessToken = req.headers.authorization.replace("Bearer ", "");
+
+    const user = await GetDiscordUser(accessToken).catch((err) => genericServerError(err, res));
+    if (!user) {
+        res.status(401);
+        res.end(`Invalid access token`);
+        return;
+    }
+
+    const guildMember = await GetGuildUser(user.id);
+    if (!guildMember) {
+        genericServerError("Unable to get guild details", res);
+        return;
+    }
+
+    // Must have a role in the body (JSON)
+    if (req.body.role) {
+        let guildRoles = await GetGuildRoles();
+        if (!guildRoles) {
+            genericServerError("Unable to get guild roles", res); return;
+        }
+
+        let roles: Role[] = guildRoles.filter(role => role.name == req.body.role);
+        if (roles.length == 0) InvalidRole(res);
+
+
+        switch (req.body.role) {
+            case "Developer":
+                guildMember.addRole(roles[0]);
+                res.send("Success");
+                break;
+            default:
+                InvalidRole(res);
+        }
+    }
+};
+
+function InvalidRole(res: Response) {
+    res.status(422);
+    res.json({
+        error: "Malformed request",
+        reason: "Invalid role"
+    });
+}

--- a/src/common/discord.ts
+++ b/src/common/discord.ts
@@ -1,0 +1,31 @@
+import * as Discord from "discord.js";
+
+export let bot: Discord.Client;
+export const uwpCommunityGuildId = "372137812037730304";
+
+export let InitBot = function () {
+    bot = new Discord.Client();
+    if (!process.env.discord_botToken) {
+        console.log(`\x1b[33m${`Missing "discord_botToken" environment variable. You will not be able to interact with the Discord bot without this`}\x1b[0m`);
+        return;
+    }
+
+    bot.once('ready', () => {
+        console.log("Server Companion bot initialized");
+
+        InitBot = () => { }; // Prevents init from being called again
+    });
+    bot.login(process.env.discord_botToken);
+};
+
+
+export function GetGuild(): Discord.Guild | undefined {
+    return bot.guilds.get(uwpCommunityGuildId);
+}
+
+export async function GetGuildUser(discordId: string): Promise<Discord.GuildMember | undefined> {
+    const server = GetGuild();
+    if (!server) return;
+
+    return (await server.members.filter(member => member.id == discordId)).first();
+}

--- a/src/common/discord.ts
+++ b/src/common/discord.ts
@@ -29,3 +29,10 @@ export async function GetGuildUser(discordId: string): Promise<Discord.GuildMemb
 
     return (await server.members.filter(member => member.id == discordId)).first();
 }
+
+export async function GetGuildRoles() {
+    const server = GetGuild();
+    if (!server) return;
+
+    return server.roles.array();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import { InitDb } from './common/sequalize';
+import { InitBot } from "./common/discord";
 
 /**
  * This file sets up API endpoints based on the current folder tree in Heroku.
@@ -41,6 +42,7 @@ app.use((req: Request, res: Response, next: NextFunction) => {
 });
 
 InitDb();
+InitBot();
 InitApi();
 
 app.listen(PORT, (err: string) => {


### PR DESCRIPTION
Merging this code into production will take the Server Companion bot online full time.

This PR adds Discord.JS and 4 endpoints regarding roles that will be utilized on the frontend:

`POST /bot/project/roles/` - Creates a role in the server for an existing app that the user owns in the Database. There are 3 "Sub roles" that are appended to the app name: "dev", "translator" and "beta tester".

On Success, it returns `200 Success`

Example body JSON: 
```json
{
	"appName": "Cortana",
	"subRole": "beta tester",
	"color": "#ffb900"
}
```

`GET /bot/user/roles/` - Gets the roles for a specific user, returning a `Discord.Role[]` if valid.

`DELETE /bot/user/role/` - Delete a role from a user. Currently, only `Developer` is supported.
`PUT /bot/user/role/` - Add a role to a user. Currently, only `Developer` is supported.

Example body JSON for PUT and DELETE above:
```json
{
	"role": "Developer"
}
```