### PR TITLE
Screen embeds and edits for swears

### DIFF
--- a/src/bot/events/messageHandlers/swearFilter.ts
+++ b/src/bot/events/messageHandlers/swearFilter.ts
@@ -1,37 +1,49 @@
-import { Message, TextChannel, DMChannel } from "discord.js";
+import { Message, TextChannel, DMChannel, PartialMessage } from "discord.js";
 import { GetGuild } from "../../../common/helpers/discord";
 
 export const swearRegex: RegExp = new RegExp(/fuck|\sass\s|dick|shit|pussy|cunt|whore|bastard|bitch|faggot|penis|slut|retarded/);
 
 export const whitelist: RegExp = new RegExp(/ishittest/);
 
-export async function handleSwearFilter(discordMessage: Message) {
-    const message = discordMessage.content.toLowerCase();
+export async function handleSwearFilter(discordMessage: PartialMessage | Message) {
+    const message = discordMessage.content?.toLowerCase() ?? ""; // A partial update might be just adding an embed, so no need to check content again
+    const checks = [message];
+    discordMessage.embeds.forEach(e => checks.push(e.title?.toLowerCase() ?? "", e.description?.toLowerCase() ?? "", e.author?.name?.toLowerCase() ?? ""));
+    let isEmbed = false; // We will show a different message if the swear is in the embed part
 
-    if (message.match(swearRegex) && !message.match(whitelist)) {
-        const sentFromChannel = discordMessage.channel as TextChannel;
-        if (!discordMessage.guild?.roles.everyone)
-            return;
+    for (const check of checks) {
+        if (check.match(swearRegex) && !check.match(whitelist)) {
+            const sentFromChannel = discordMessage.channel as TextChannel;
+            if (!discordMessage.guild?.roles.everyone)
+                return;
 
-        const channelPermsForAll = sentFromChannel.permissionsFor(discordMessage.guild.roles.everyone);
+            const channelPermsForAll = sentFromChannel.permissionsFor(discordMessage.guild.roles.everyone);
 
-        // If the channel is private, don't filter
-        if (channelPermsForAll && !channelPermsForAll.has("VIEW_CHANNEL")) {
-            return;
-        }
+            // If the channel is private, don't filter
+            if (channelPermsForAll && !channelPermsForAll.has("VIEW_CHANNEL")) {
+                return;
+            }
 
-        const dm: DMChannel = await discordMessage.author.createDM();
-        await dm.send(`Your message was removed because it contained a swear word.
+            await discordMessage.fetch(); // Partial messages need to be resolved at this point. Does nothing if not partial
+            if (!discordMessage.partial) { // This allows us to access properties that could have been null before fetching
+                const dm: DMChannel = await discordMessage.author.createDM();
+                await dm.send(`Your message was removed because it contained a swear word${isEmbed ? " in an embed" : ""}.
 > ${discordMessage.content}`);
 
-        const guild = await GetGuild();
-        const author = discordMessage.author;
-        if (guild) {
-            const botChannel = guild.channels.cache.find(i => i.name == "bot-stuff") as TextChannel;
-            botChannel.send(`A swear word from \`${author.username}#${author.discriminator}\` (ID ${author.id}) sent in <#${sentFromChannel.id}> was removed:
-> ${message}`);
+                const guild = await GetGuild();
+                const author = discordMessage.author;
+                if (guild) {
+                    const botChannel = guild.channels.cache.find(i => i.name == "bot-stuff") as TextChannel;
+                    botChannel.send(`A swear word from \`${author.username}#${author.discriminator}\` (ID ${author.id}) sent in <#${sentFromChannel.id}> was removed:
+> ${discordMessage.content}${isEmbed ? "\n\nOffending part of embed:\n> " + check : ""}`);
+                }
+            }
+
+            await discordMessage.delete();
+
+            break;
         }
 
-        await discordMessage.delete();
+        isEmbed = true; // First iteration will always be message content, even if empty
     }
 }

--- a/src/bot/events/messageUpdate.ts
+++ b/src/bot/events/messageUpdate.ts
@@ -1,0 +1,6 @@
+import { PartialMessage } from "discord.js";
+import { handleSwearFilter } from "./messageHandlers/swearFilter";
+
+export default (oldDiscordMessage: PartialMessage, newDiscordMessage: PartialMessage) => {
+    handleSwearFilter(newDiscordMessage);
+}


### PR DESCRIPTION
This would delete messages if they had embeds with swears in them. It would also delete messages that are edited to contain swears. The edit step is important for embeds because sometimes Discord adds embeds to messages a few seconds after they are sent via the messageUpdate event.