### PR TITLE
Improve swear word, delete and infraction messages

### DIFF
--- a/src/bot/events/messageDelete.ts
+++ b/src/bot/events/messageDelete.ts
@@ -1,4 +1,4 @@
-import { Message, TextChannel } from "discord.js";
+import { Message, MessageFlags, TextChannel } from "discord.js";
 import { GetChannelByName } from "../../common/helpers/discord";
 
 export default async (discordMessage: Message) => {
@@ -12,5 +12,11 @@ export default async (discordMessage: Message) => {
         return;
     }
 
-    botstuffChannel.send(`Message from <@${discordMessage.author.id}> was deleted from ${(discordMessage.channel as TextChannel).name}:\n> ${discordMessage.content}`)
+    botstuffChannel.send({
+        content: `Message from <@${discordMessage.author.id}> was deleted from <#${discordMessage.channel.id}>:\n>>> ${discordMessage.content}`,
+        allowedMentions: {
+            parse: []
+        },
+        flags: MessageFlags.SuppressEmbeds
+    })
 }

--- a/src/bot/events/messageHandlers/swearFilter.ts
+++ b/src/bot/events/messageHandlers/swearFilter.ts
@@ -1,4 +1,4 @@
-import { Message, TextChannel, DMChannel, PartialMessage } from "discord.js";
+import { Message, TextChannel, DMChannel, PartialMessage, MessageFlags } from "discord.js";
 import { GetGuild } from "../../../common/helpers/discord";
 
 export const swearRegex: RegExp = new RegExp(/fuck|\sass\s|dick|shit|pussy|cunt|whore|bastard|bitch|faggot|penis|slut|retarded/);
@@ -29,8 +29,7 @@ export async function handleSwearFilter(discordMessage: PartialMessage | Message
                 try {
                     // If the user has turned off DMs from all server members, this will throw
                     const dm: DMChannel = await discordMessage.author.createDM();
-                    await dm.send(`Your message was removed because it contained a swear word${isEmbed ? " in an embed" : ""}.
-                    > ${discordMessage.content}`);
+                    await dm.send(`Your message was removed because it contained a swear word${isEmbed ? " in an embed" : ""}.\n>>> ${discordMessage.content}`);
                 } catch {
                     var tick = 5;
                     var baseMsg = `<@${discordMessage.author.id}> Swear word was removed, see rule 4.\nThis message will self destruct in `;
@@ -53,8 +52,13 @@ export async function handleSwearFilter(discordMessage: PartialMessage | Message
                 const author = discordMessage.author;
                 if (guild) {
                     const botChannel = guild.channels.cache.find(i => i.name == "bot-stuff") as TextChannel;
-                    botChannel.send(`A swear word from \`${author.username}#${author.discriminator}\` (ID ${author.id}) sent in <#${sentFromChannel.id}> was removed:
-> ${discordMessage.content}${isEmbed ? "\n\nOffending part of embed:\n> " + check : ""}`);
+                    botChannel.send({
+                        content: `A swear word from <@${author.id}> sent in <#${sentFromChannel.id}> was removed:\n>>> ${discordMessage.content}${isEmbed ? "\n\nOffending part of embed:\n>>> " + check : ""}`,
+                        allowedMentions: {
+                            parse: []
+                        },
+                        flags: MessageFlags.SuppressEmbeds
+                    });
                 }
             }
 

--- a/src/bot/events/messageHandlers/swearFilter.ts
+++ b/src/bot/events/messageHandlers/swearFilter.ts
@@ -1,14 +1,17 @@
 import { Message, TextChannel, DMChannel, PartialMessage, MessageFlags } from "discord.js";
 import { GetGuild } from "../../../common/helpers/discord";
 
-export const swearRegex: RegExp = new RegExp(/fuck|\sass\s|dick|shit|pussy|cunt|whore|bastard|bitch|faggot|penis|slut|retarded/);
+export const swearRegex: RegExp = new RegExp(/fuck|\sass\s|dick|shit|pussy|cunt|whore|bastard|bitch|faggot|penis|slut|retarded/i);
 
-export const whitelist: RegExp = new RegExp(/ishittest/);
+export const whitelist: RegExp = new RegExp(/ishittest/i);
 
 export async function handleSwearFilter(discordMessage: PartialMessage | Message) {
-    const message = discordMessage.content?.toLowerCase() ?? ""; // A partial update might be just adding an embed, so no need to check content again
+    const message = discordMessage.content ?? ""; // A partial update might be just adding an embed, so no need to check content again
     const checks = [message];
-    discordMessage.embeds.forEach(e => checks.push(e.title?.toLowerCase() ?? "", e.description?.toLowerCase() ?? "", e.author?.name?.toLowerCase() ?? ""));
+    discordMessage.embeds.forEach(e => {
+        checks.push(e.title ?? "", e.description ?? "", e.footer?.text ?? "", e.provider?.name ?? "", e.author?.name ?? "");
+        e.fields?.forEach(f => checks.push(f.name, f.value));
+    });
     let isEmbed = false; // We will show a different message if the swear is in the embed part
 
     for (const check of checks) {

--- a/src/bot/events/messageHandlers/swearFilter.ts
+++ b/src/bot/events/messageHandlers/swearFilter.ts
@@ -53,7 +53,7 @@ export async function handleSwearFilter(discordMessage: PartialMessage | Message
                 if (guild) {
                     const botChannel = guild.channels.cache.find(i => i.name == "bot-stuff") as TextChannel;
                     botChannel.send({
-                        content: `A swear word from <@${author.id}> sent in <#${sentFromChannel.id}> was removed:\n>>> ${discordMessage.content}${isEmbed ? "\n\nOffending part of embed:\n>>> " + check : ""}`,
+                        content: `A swear word ${isEmbed ? "in an embed " : ""}from <@${author.id}> sent in <#${sentFromChannel.id}> was removed:\n>>> ${check}`,
                         allowedMentions: {
                             parse: []
                         },


### PR DESCRIPTION
No longer pings a mod when they delete their own messages or swear

Also directly mention mod rather than name since it will not ping them

Removes embeds from logged messages

Use >>> to handle new lines properly when quoting user-generated text

Use channel mentions instead of channel name